### PR TITLE
Create dropdown fields

### DIFF
--- a/src/components/Servants/ServantForm.js
+++ b/src/components/Servants/ServantForm.js
@@ -7,7 +7,7 @@ const ServantForm = ({ servant, handleChange, handleSubmit }) => {
 
   // An object containing the key names of my servant schema, with each value
   // being the way I'd like them displayed to the user
-  const keys = {
+  const keyNames = {
     name: 'Name',
     sclass: 'Class',
     rarity: 'Rarity',
@@ -15,25 +15,77 @@ const ServantForm = ({ servant, handleChange, handleSubmit }) => {
     atk: 'Attack',
     hp: 'HP'
   }
+  // list of servant class names, to be used for populating the Class dropdown
+  const classList = ['Saber', 'Lancer', 'Archer', 'Rider', 'Caster', 'Assassin', 'Berserker', 'Ruler', 'Avenger', 'Alter Ego', 'Moon Cancer', 'Shielder']
+  const textFieldJsx = key => {
+    return (
+    // `key` will be passed in from formFieldsJsx which maps through an array
+    // of all the key names of my `keyNames` object
 
-  // Object.keys returns an array containing the names of all of the keys, which
-  // I can then iterate through
-  const formFieldsJsx = Object.keys(keys).map(key => (
     // For places where I want the value to be the same as the key used in the
     // schema, I can simply use `key`
-    // For places where I want the nice capitalized display name, and in the case of
-    // sclass, don't want to deal with removing the s from the beginning, I use
-    // keys[key], which will give me the matching string from the original object
-    <Form.Group controlId={key} key={key}>
-      <Form.Label>{keys[key]}</Form.Label>
+
+    // For places where I want the nice capitalized display name, and in the
+    // case of sclass, don't want to deal with removing the s from the
+    // beginning, I use keyNames[key], which will give me the matching string
+    // from the original object
       <Form.Control
-        type={key}
-        placeholder={keys[key]}
+        type='text'
+        placeholder={keyNames[key]}
         name={key}
         onChange={handleChange}
         value={servant[key]}
         required
       />
+    )
+  }
+  // For the `rarity` and `sclass` fields I want a dropdown rather than a text
+  // field
+  const dropdownFieldJsx = (key) => {
+    let values = []
+    if (key === 'rarity') {
+      // if the key passed down is `rarity` then the values to iterate through
+      // will be the rarity levels
+      values = [0, 1, 2, 3, 4, 5]
+    } else {
+      // otherwise they will be the class names
+      values = classList
+    }
+    return (
+      <Form.Control
+        as='select'
+        placeholder={keyNames[key]}
+        name={key}
+        onChange={handleChange}
+        value={servant[key]}
+        required>
+        {/* map through the `values` array, which will a range of 0 through 5
+          for `rarity`, or a list of class names for `sclass` */}
+        {values.map(e => (
+          // if `servant[key]` (with `key` being either `rarity` or `sclass`)
+          // matches the option being created, set it as the selected option
+          <option key={e} selected={servant[key] === e}>{e}</option>
+        ))}
+      </Form.Control>
+    )
+  }
+
+  // Takes in a key name from formFieldsJsx and determines which field to return
+  const determineField = key => {
+    if (key === 'sclass' || key === 'rarity') {
+      // if the key is `sclass` or `rarity` then it will return the dropdown component
+      return dropdownFieldJsx(key)
+    } else {
+      // otherwise it will return the `textFieldJsx` component
+      return textFieldJsx(key)
+    }
+  }
+  // Object.keys returns an array containing the names of all of the keys, which
+  // I can then iterate through
+  const formFieldsJsx = Object.keys(keyNames).map(key => (
+    <Form.Group controlId={key} key={key}>
+      <Form.Label>{keyNames[key]}</Form.Label>
+      {determineField(key)}
     </Form.Group>
   ))
 


### PR DESCRIPTION
- Make `dropdownFieldJsx` which takes a key as an argument and returns a
dropdown list for either `rarity` or `sclass`. Also sets the matching
option to be selected if there is a servant currently being edited.
- Make `textFieldJsx` which returns the previously written jsx component
of a text field with the correct `placeholder` `name` and `value` fields
filled in.
- Make a component which takes in a key from `formFieldsJsx`, determines
if that key should have a text field or a dropdown field, and returns
the appropriate component